### PR TITLE
Fix bootstrap styles attaching via HTML Imports,

### DIFF
--- a/src/StarcounterClientFiles/wwwroot/sys/bootstrap.html
+++ b/src/StarcounterClientFiles/wwwroot/sys/bootstrap.html
@@ -1,8 +1,10 @@
-﻿<!-- A theme of choice. Bootswatch Paper theme by default -->
-<link rel="stylesheet" href="/sys/bootswatch/paper/bootstrap.css">
 <script>
 (function(){
-    var importDoc = document.currentScript.ownerDocument;
-    document.head.appendChild(importDoc.firstElementChild);
+    // <!-- A theme of choice. Bootswatch Paper theme by default -->
+    // <link rel="stylesheet" href="/sys/bootswatch/paper/bootstrap.css">
+    const bootstrap = document.createElement('link');
+    bootstrap.href = '/sys/bootswatch/paper/bootstrap.css';
+    bootstrap.rel = 'stylesheet';
+    document.head.appendChild(bootstrap);
 })();
 </script>


### PR DESCRIPTION
Was rendering white page in Firefox.
As `.ownerDocument` is no longer what it should with the new polyfill.
Related https://github.com/Starcounter/KitchenSink/pull/208


Clone of https://github.com/Starcounter/StarcounterClientFiles/pull/17 after github's auto-closing.