### PR TITLE
Add warehouse publishing steps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ The developer process of releasing of a new version of StarcounterClientFiles `3
 5. When you push to a feature branch of StarcounterClientFiles, TeamCity will run a integration test of this branch with KitchenSink and Blending. Make sure these tests are passing.
 6. Make a PR for someone to review the complete set of changes.
 7. Still in the feature branch, push a tag (3.x.y), and add release notes to GitHub release of StarcounterClientFiles.
-8. Still in the feature branch, publish a package of this version to App Warehouse (built with Starcounter 2.4)
+8. Still in the feature branch, publish a package of this version to App Warehouse (built with Starcounter 2.4). You may follow the steps to do this [here](https://github.com/Starcounter/CompanyTrack/blob/master/AppsTeam/Guidelines/releasing-to-warehouse.md). 
 9. Execute [package.bat](https://github.com/Starcounter/StarcounterClientFiles/blob/3.x/package.bat)
     * this will create a nuget package of StarcounterClientFiles called `Starcounter.ClientFiles` to folder `/StarcounterClientFiles/artifacts/Starcounter.ClientFiles.X.Y.Z.nupkg`
 10. Execute [push_nuget_package.bat](https://github.com/Starcounter/StarcounterClientFiles/blob/3.x/push_nuget_package.bat)


### PR DESCRIPTION
Because some people aren't aware what this means:

"Still in the feature branch, publish a package of this version to App Warehouse (built with Starcounter 2.4)"