### PR TITLE
Add and import enlighted-link

### DIFF
--- a/src/StarcounterClientFiles/Properties/AssemblyInfo.cs
+++ b/src/StarcounterClientFiles/Properties/AssemblyInfo.cs
@@ -33,10 +33,10 @@ using Starcounter.Internal;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyInformationalVersion("3.6.1")]
+[assembly: AssemblyInformationalVersion("3.7.0")]
 
-[assembly: AssemblyVersion("3.6.1")]
-[assembly: AssemblyFileVersion("3.6.1")]
+[assembly: AssemblyVersion("3.7.0")]
+[assembly: AssemblyFileVersion("3.7.0")]
 
 // Assures the current assembly has a reference to the Starcounter
 // assembly. A reference to Starcounter is currently required for

--- a/src/StarcounterClientFiles/bower-list.txt
+++ b/src/StarcounterClientFiles/bower-list.txt
@@ -1,5 +1,7 @@
 ﻿bower check-new     Checking for new versions of the project dependencies...
 starcounter-clientfiles#2.1.1 C:\Work\Starcounter\StarcounterClientFiles\src\StarcounterClientFiles
+├─┬ enlighted-link#0.0.1
+│ └── webcomponentsjs#1.2.0 (latest is 2.0.0-beta.2)
 ├─┬ imported-template#3.2.0
 │ └── juicy-html#4.0.0
 ├─┬ palindrom-client#5.0.0 (latest is 6.0.0)
@@ -53,5 +55,5 @@ starcounter-clientfiles#2.1.1 C:\Work\Starcounter\StarcounterClientFiles\src\Sta
 │ │ │   └── polymer not installed
 │ │ └─┬ vaadin-themable-mixin#1.1.6
 │ │   └── polymer not installed
-│ └── webcomponentsjs#1.2.0 (latest is 2.0.0-beta.2)
+│ └── webcomponentsjs#1.2.0
 └── webcomponentsjs#1.2.0 (latest is 2.0.0-beta.2)

--- a/src/StarcounterClientFiles/bower.json
+++ b/src/StarcounterClientFiles/bower.json
@@ -10,7 +10,8 @@
     "polymer-source": "polymer#^2.0.0",
     "webcomponentsjs": "^1.0.0",
     "underwear.css": "~0.0.7",
-    "uniform.css": "^0.2.2"
+    "uniform.css": "^0.2.2",
+    "enlighted-link": "^0.0.1"
   },
   "resolutions": {
     "fast-json-patch": "^1.1.0",

--- a/src/StarcounterClientFiles/wwwroot/sys/enlighted-link/.bower.json
+++ b/src/StarcounterClientFiles/wwwroot/sys/enlighted-link/.bower.json
@@ -1,0 +1,38 @@
+{
+  "name": "enlighted-link",
+  "version": "0.0.1",
+  "description": "Awesome, Juicy Custom Element",
+  "license": "MIT",
+  "main": "enlighted-link.html",
+  "keywords": [
+    "web-components",
+    "juicy"
+  ],
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "preview.png",
+    "package.json",
+    "Gruntfile.json"
+  ],
+  "dependencies": {
+    "webcomponentsjs": "^1.1.1"
+  },
+  "devDependencies": {
+    "web-component-tester": "^6.5.0",
+    "juicy-ace-editor": "^2.0.5"
+  },
+  "homepage": "https://github.com/Juicy/enlighted-link",
+  "_release": "0.0.1",
+  "_resolution": {
+    "type": "version",
+    "tag": "0.0.1",
+    "commit": "394701cfab5012694b74353632e983fdb6179816"
+  },
+  "_source": "https://github.com/Juicy/enlighted-link.git",
+  "_target": "^0.0.1",
+  "_originalSource": "enlighted-link",
+  "_direct": true
+}

--- a/src/StarcounterClientFiles/wwwroot/sys/enlighted-link/CONTRIBUTING.md
+++ b/src/StarcounterClientFiles/wwwroot/sys/enlighted-link/CONTRIBUTING.md
@@ -1,0 +1,80 @@
+# Contributing
+
+We welcome and truly appreciate contribution in all forms - issues, pull requests, questions, or fancy examples of apps/elements build on to of your elements.
+
+## Filing bugs
+
+Our team heavily uses Github for all of our software management. We use Github issues to track all bugs and features.
+
+If you find an issue, please do file it on the repository.
+
+We love examples for addressing issues - issues with a Plunkr, [jsFiddle](http://jsfiddle.net), or [jsBin](http://jsbin.com) will be much easier for us to work on quickly. You can start with [this jsbin](http://jsbin.com/capequ/edit?html,output) which sets up the basics to demonstrate a Juicy element.
+
+Occasionally we'll close issues if they appear stale or are too vague - please don't take this personally! Please feel free to re-open issues we've closed if there's something we've missed and they still need to be addressed.
+
+## Developing the element
+
+If you would like to start to fiddle with element's code, here is the flow we use.
+
+- Make a local clone of this repo: `git clone git@github.com:Juicy/enlighted-link.git`
+
+In order to develop it locally we suggest to use [polyserve](https://npmjs.com/polyserve) tool to handle bower paths gently.
+
+0. Go to the repo's directory: `cd enlighted-link`
+1. Install [bower](http://bower.io/) & [polyserve](https://npmjs.com/polyserve): `$ npm install -g bower polyserve`
+2. Install local dependencies: `$ bower install`
+3. Start development server `$ polyserve -p 8000`
+4. Open the demo/preview: [http://localhost:8000/components/enlighted-link/](http://localhost:8000/components/enlighted-link/)
+5. Open the test suite: [http://localhost:8000/components/enlighted-link/test/](http://localhost:8000/components/enlighted-link/test/)
+
+## Contributing Pull Requests
+
+1. Fork it!
+2. Create your feature branch: `git checkout -b my-new-feature`
+3. Commit your changes: `git commit -m 'Add some feature'`
+4. Push to the branch: `git push origin my-new-feature`
+5. Open corresponding issue if needed
+6. Submit a pull request :D
+
+
+### Styleguide
+
+`.jscs.json`/`.jscsrc`/`package.json` to be linked
+
+## Unit tests
+
+All Juicy custom elements projects use [`web-component-tester`](https://github.com/Polymer/web-component-tester) for unit tests.
+The [`polyserve`](https://github.com/PolymerLabs/polyserve) utility is helpful for [running tests in the browser](#developing-the-element).
+
+
+
+### Running element unit tests from CLI
+
+To run the element unit tests from CLI, you need to:
+
+0.  Install `web-component-tester` globally: `npm install -g web-component-tester`
+1.  Clone the element repo.
+2.  Install the dependencies. `bower install`
+3.  Run the tests: `wct`
+
+#### Configuring `web-component-tester`
+
+By default, `web-component-tester` runs tests on all installed browsers. You can configure it
+to run tests on a subset of available browsers, or to run tests remotely using Sauce Labs.
+
+See the [`web-component-tester` README](https://github.com/Polymer/web-component-tester) for
+information on configuring the tool.
+
+## Releasing a new version
+
+**The release is done from `master` branch.**
+
+1. Make sure that the browser tests pass in Chrome, Firefox, Edge and IE. This can be done manually or using `npm run test` (see instructions above).
+2. Call `git status` to verify that there are no uncommited files in the directory
+3. Call `grunt bump:patch`, `grunt bump:minor` or `grunt bump:major`. This command:
+ - increments the version number in the relevant files
+ - commits changes to Git with the version number as the commit message
+ - creates a Git tag wit the version
+4. Call `git push` to push the changes to `origin master`
+5. Call `git push --tags` to push the tag to `origin master`
+6. Explain the changes (at least an summary of the commit log) in [GitHub Releases](https://github.com/Juicy/enlighted-link/releases).

--- a/src/StarcounterClientFiles/wwwroot/sys/enlighted-link/Gruntfile.js
+++ b/src/StarcounterClientFiles/wwwroot/sys/enlighted-link/Gruntfile.js
@@ -1,0 +1,24 @@
+module.exports = function(grunt) {
+
+    grunt.initConfig({
+        bump: {
+          options: {
+            files: ['package.json', 'bower.json', 'enlighted-link.html'],
+            commit: true,
+            commitMessage: '%VERSION%',
+            commitFiles: ['package.json', 'bower.json', 'enlighted-link.html'],
+            createTag: true,
+            tagName: '%VERSION%',
+            tagMessage: 'Version %VERSION%',
+            push: false,
+            // pushTo: 'origin',
+            globalReplace: false,
+            prereleaseName: false,
+            regExp: false
+          }
+        }
+    });
+;
+    grunt.loadNpmTasks('grunt-bump');
+
+};

--- a/src/StarcounterClientFiles/wwwroot/sys/enlighted-link/LICENSE
+++ b/src/StarcounterClientFiles/wwwroot/sys/enlighted-link/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) 2016 Starcounter AB
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/StarcounterClientFiles/wwwroot/sys/enlighted-link/README.md
+++ b/src/StarcounterClientFiles/wwwroot/sys/enlighted-link/README.md
@@ -1,0 +1,68 @@
+# &lt;enlighted-link&gt;
+
+> Custom element to enlight your `<link>`s from Shadow DOM to the Light.
+
+By current spec [HTML Imports do not work in Shadow DOM](https://github.com/w3c/webcomponents/issues/628). That makes it hard to import definitions of custom elements that you use in a shadow root. This element allows you to do that. You could import your dependencies exactly where and when you need them.
+
+## Demo
+
+[Check it live!](http://Juicy.github.io/enlighted-link)
+
+## Install
+
+Install the component using [Bower](http://bower.io/):
+
+```sh
+$ bower install enlighted-link --save
+```
+
+Or [download as ZIP](https://github.com/Juicy/enlighted-link/archive/master.zip).
+
+## Usage
+
+1. Import polyfill:
+
+    ```html
+    <script src="bower_components/webcomponentsjs/webcomponent-lite.js"></script>
+    ```
+
+2. Import custom element:
+
+    ```html
+    <link rel="import" href="bower_components/enlighted-link/enlighted-link.html">
+    ```
+
+3. Start using it!
+
+    ```html
+    <div>
+        #shadow-root
+            <enlighted-link rel="import" href="path/to/some-thing.html"></enlighted-link>
+            <!-- now you can use whatever you imported -->
+            <some-thing></some-thing>
+        #/shadow-root
+    </div>
+    ```
+
+## Options
+
+The element forwards [`link` element's content attributes](https://dev.w3.org/html5/spec-preview/the-link-element.html), to the eventually created `<link>` in light DOM.
+
+- href
+- rel
+- media
+- hreflang
+- type
+- sizes
+- title
+
+
+## [Contributing and Development](CONTRIBUTING.md)
+
+## History
+
+For detailed changelog, check [Releases](https://github.com/Juicy/enlighted-link/releases).
+
+## License
+
+MIT

--- a/src/StarcounterClientFiles/wwwroot/sys/enlighted-link/bower.json
+++ b/src/StarcounterClientFiles/wwwroot/sys/enlighted-link/bower.json
@@ -1,0 +1,27 @@
+{
+  "name": "enlighted-link",
+  "version": "0.0.1",
+  "description": "Awesome, Juicy Custom Element",
+  "license": "MIT",
+  "main": "enlighted-link.html",
+  "keywords": [
+    "web-components",
+    "juicy"
+  ],
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "preview.png",
+    "package.json",
+    "Gruntfile.json"
+  ],
+  "dependencies": {
+    "webcomponentsjs": "^1.1.1"
+  },
+  "devDependencies": {
+    "web-component-tester": "^6.5.0",
+    "juicy-ace-editor": "^2.0.5"
+  }
+}

--- a/src/StarcounterClientFiles/wwwroot/sys/enlighted-link/enlighted-link.html
+++ b/src/StarcounterClientFiles/wwwroot/sys/enlighted-link/enlighted-link.html
@@ -1,0 +1,38 @@
+<!-- enlighted-link @version: 0.0.1 @license: MIT -->
+<script>
+customElements.define('enlighted-link', class extends HTMLElement{
+    static get observedAttributes(){
+        return [
+            // content attrs
+            'href',
+            'rel',
+            'media',
+            'hreflang',
+            'type',
+            'sizes',
+            'title'
+        ]
+    }
+    connectedCallback(){
+        const link = this.link = this.link || document.createElement('link');
+
+        for(let attrNo = 0, len = this.attributes.length; attrNo < len; attrNo++){
+            link.setAttribute(this.attributes[attrNo].name, this.attributes[attrNo].value);
+        }
+        document.head.appendChild(link);
+        // IDEA(tomalec): attach mutation observer on links parent, to detach this in case link is detached.
+    }
+    disconnectedCallback(){
+        this.link.remove();
+    }
+    attributeChangedCallback(name, oldVal, newVal){
+        if(this.link){
+            if(newVal !== null){
+                this.link.setAttribute(name, newVal);
+            } else {
+                this.link.removeAttribute(name);
+            }
+        }
+    }
+});
+</script>

--- a/src/StarcounterClientFiles/wwwroot/sys/enlighted-link/index.html
+++ b/src/StarcounterClientFiles/wwwroot/sys/enlighted-link/index.html
@@ -1,0 +1,103 @@
+<!doctype html>
+<html>
+<head>
+
+    <meta charset="utf-8">
+    <title>&lt;enlighted-link&gt;</title>
+    <link rel="stylesheet" href="https://juicy.github.io/github-markdown-css/github-markdown.css">
+
+
+    <!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.0.10/webcomponents-lite.js"></script> -->
+    <script src="../webcomponentsjs/webcomponents-lite.js"></script>
+
+
+
+    <!-- Imports custom element -->
+    <link rel="import" href="enlighted-link.html">
+</head>
+<body class="markdown-body">
+    <template is="shadow-root" mode="open">
+        <enlighted-link rel="import" href="../juicy-ace-editor/juicy-ace-editor.html"></enlighted-link>
+        <style>
+            :host(.markdown-body){
+                height: 100%;
+                margin: 1em auto;
+                width: 70%;
+            }
+            img{
+                position: absolute;
+                top: 0;
+                right: 0;
+                border: 0;
+            }
+            #panes{
+                display: grid;
+                gap: 1em;
+                grid-template: "solves codehead" min-content
+                               "solves codesample" minmax(6em, 1fr) / 50% 50%;
+            }
+            #panes>:first-child{
+                grid-area: solves;
+            }
+            /** Support for ShadyDOM polyfilled browsers FF and Edge
+            https://github.com/webcomponents/shadycss/issues/128     */
+            .markdown-body{
+                height: 100%;
+                margin: 1em auto;
+                width: 70%;
+            }
+        </style>
+        <a href="https://github.com/Juicy/enlighted-link"><img src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"></a>
+
+        <slot name="header"></slot>
+        <div id="panes">
+            <div>
+                <slot name="solves"></slot>
+            </div>
+            <div><slot name="code-heading"></slot></div>
+            <juicy-ace-editor>&lt;anyelement&gt;
+    &lt;shadow-root&gt;
+        &lt;enlighted-link rel="import" href="path/to/your-element.html"&gt;
+        &lt;your-element&gt;&lt;slot&gt;&lt;/slot&gt;&lt;/your-element&gt;
+    &lt;/shadow-root&gt;
+    Light DOM content here
+&lt;/anyelement&gt;<slot name="code-sample"><!-- To be updated after https://github.com/Juicy/juicy-ace-editor/issues/40 --></slot></juicy-ace-editor>
+            </div>
+        </div>
+        <slot></slot>
+    </template>
+    <h1 slot="header">enlighted-link</h1>
+    <blockquote slot="header">
+        Custom element to enlight your <code>&lt;link&gt;</code>`s from Shadow DOM to the Light.
+    </blockquote>
+
+    <p slot="solves">
+        By current spec <a href="https://github.com/w3c/webcomponents/issues/628">HTML Imports do not work in Shadow DOM</a>.
+        That makes it hard to import definitions of custom elements that you use in a shadow root.
+    </p>
+    <p slot="solves">
+        This element allows you to do that. You could import your dependencies exactly where and when you need them.
+    </p>
+    <strong slot="code-heading">
+        Check the source of this page. Now, you can simply do:
+    </strong>
+    <code slot="code-sample">&lt;anyelement&gt;
+&lt;shadow-root&gt;
+    &lt;enlighted-link rel="import" href="path/to/your-element.html"&gt;
+    &lt;your-element&gt;&lt;slot&gt;&lt;/slot&gt;&lt;/your-element&gt;
+&lt;/shadow-root&gt;
+Light DOM content here
+&lt;/anyelement&gt;
+    </code>
+    <p>For more check the <a href="https://github.com/Juicy/enlighted-link/blob/master/README.md">README.md</a></p>
+
+</body>
+<script>
+(function(){
+    Array.from(document.querySelectorAll('[is="shadow-root"]'), (templ)=>{
+        templ.parentNode.attachShadow({mode: templ.getAttribute('mode')});
+        templ.parentNode.shadowRoot.appendChild(document.importNode(templ.content, true));
+    })
+}())
+</script>
+</html>

--- a/src/StarcounterClientFiles/wwwroot/sys/enlighted-link/wct.conf.json
+++ b/src/StarcounterClientFiles/wwwroot/sys/enlighted-link/wct.conf.json
@@ -1,0 +1,18 @@
+{
+    "verbose": false,
+    "plugins": {
+        "local": {
+            "browsers": ["chrome", "firefox"]
+        },
+        "sauce": {
+            "browsers": [{
+                "browserName": "microsoftedge",
+                "platform": "Windows 10"
+            }, {
+                "browserName": "safari",
+                "platform": "OS X 10.11",
+                "version": "10"
+            }]
+        }
+    }
+}

--- a/src/StarcounterClientFiles/wwwroot/sys/starcounter.html
+++ b/src/StarcounterClientFiles/wwwroot/sys/starcounter.html
@@ -1,4 +1,5 @@
 <link rel="import" href="palindrom-client/palindrom-client.html">
+<link rel="import" href="enlighted-link/enlighted-link.html">
 <link rel="import" href="/sys/starcounter-include/starcounter-include.html">
 <script>
     (function () {


### PR DESCRIPTION
Add [Juicy/enlighted-link](https://github.com/Juicy/enlighted-link)@0.0.1, to allow importing dependencies from shadow roots


Import it in starcounter.html, so any composition could use it.

https://github.com/Starcounter/RebelsLounge/issues/258