### PR TITLE
Load full uniform in app-shell

### DIFF
--- a/src/StarcounterClientFiles/wwwroot/sys/app-shell/app-shell.html
+++ b/src/StarcounterClientFiles/wwwroot/sys/app-shell/app-shell.html
@@ -7,7 +7,7 @@
     <script src="/sys/webcomponentsjs/webcomponents-lite.js"></script>
     <link rel="import" href="/sys/polymer/polymer.html">
     <link rel="import" href="/sys/starcounter.html">
-    <link rel="stylesheet" href="/sys/uniform.css/dist/uniform.css">
+    <link rel="stylesheet" href="/sys/uniform.css/uniform.css">
     <link rel="manifest">
 </head>
 <body>

--- a/src/StarcounterClientFiles/wwwroot/sys/app-shell/app-shell.html
+++ b/src/StarcounterClientFiles/wwwroot/sys/app-shell/app-shell.html
@@ -7,6 +7,7 @@
     <script src="/sys/webcomponentsjs/webcomponents-lite.js"></script>
     <link rel="import" href="/sys/polymer/polymer.html">
     <link rel="import" href="/sys/starcounter.html">
+    <link rel="preload" href="/sys/uniform.css/uniform.css">
     <link rel="stylesheet" href="/sys/uniform.css/uniform.css">
     <link rel="manifest">
 </head>

--- a/src/StarcounterClientFiles/wwwroot/sys/app-shell/app-shell.html
+++ b/src/StarcounterClientFiles/wwwroot/sys/app-shell/app-shell.html
@@ -7,7 +7,7 @@
     <script src="/sys/webcomponentsjs/webcomponents-lite.js"></script>
     <link rel="import" href="/sys/polymer/polymer.html">
     <link rel="import" href="/sys/starcounter.html">
-    <link rel="stylesheet" href="/sys/uniform.css/dist/underwear.css">    
+    <link rel="stylesheet" href="/sys/uniform.css/dist/uniform.css">
     <link rel="manifest">
 </head>
 <body>

--- a/src/StarcounterClientFiles/wwwroot/sys/app-shell/app-shell.html
+++ b/src/StarcounterClientFiles/wwwroot/sys/app-shell/app-shell.html
@@ -7,7 +7,6 @@
     <script src="/sys/webcomponentsjs/webcomponents-lite.js"></script>
     <link rel="import" href="/sys/polymer/polymer.html">
     <link rel="import" href="/sys/starcounter.html">
-    <link rel="preload" href="/sys/uniform.css/uniform.css">
     <link rel="stylesheet" href="/sys/uniform.css/uniform.css">
     <link rel="manifest">
 </head>


### PR DESCRIPTION
5 seconds review. I tested with UniformDocs and all looks good with this app-shell (viewed by view-source):

```html
<!DOCTYPE html>
<html>
<head>
    <meta charset="utf-8">
    <title>UniformDocs</title>

    <script src="/sys/webcomponentsjs/webcomponents-lite.js"></script>
    <link rel="import" href="/sys/polymer/polymer.html">
    <link rel="import" href="/sys/starcounter.html">
    <link rel="stylesheet" href="/sys/uniform.css/dist/uniform.css">    
    <link rel="manifest">
</head>
<body>
    <dom-bind id="palindrom-root">
        <template>
            <starcounter-include view-model="{{model}}"></starcounter-include>
        </template>
    </dom-bind>
    
    <palindrom-client ref="palindrom-root" remote-url="/__default/AFEF5BB6513EFE1E7D000020"></palindrom-client>
</body>
</html>
```

Fixes: https://github.com/Starcounter/StarcounterClientFiles/issues/102