### PR TITLE
Parent composition

### DIFF
--- a/src/StarcounterClientFiles/Properties/AssemblyInfo.cs
+++ b/src/StarcounterClientFiles/Properties/AssemblyInfo.cs
@@ -33,10 +33,10 @@ using Starcounter.Internal;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyInformationalVersion("3.11.1")]
+[assembly: AssemblyInformationalVersion("3.12.0")]
 
-[assembly: AssemblyVersion("3.11.1")]
-[assembly: AssemblyFileVersion("3.11.1")]
+[assembly: AssemblyVersion("3.12.0")]
+[assembly: AssemblyFileVersion("3.12.0")]
 
 // Assures the current assembly has a reference to the Starcounter
 // assembly. A reference to Starcounter is currently required for

--- a/src/StarcounterClientFiles/bower-list.txt
+++ b/src/StarcounterClientFiles/bower-list.txt
@@ -11,6 +11,8 @@ starcounter-clientfiles#3.9.0 C:\Work\Starcounter\StarcounterClientFiles\src\Sta
 ├─┬ polymer-source#2.6.0 (latest is 3.0.2)
 │ ├── shadycss#1.3.1 (1.3.5 available)
 │ └── webcomponentsjs#1.2.2 (1.2.3 available, latest is 2.0.3)
+├─┬ slot-all#0.0.1
+│ └── webcomponentsjs#1.2.2
 ├─┬ starcounter-include#5.1.0
 │ └── imported-template#3.2.1
 ├─┬ uniform.css#0.4.1

--- a/src/StarcounterClientFiles/bower-list.txt
+++ b/src/StarcounterClientFiles/bower-list.txt
@@ -1,7 +1,7 @@
 bower check-new     Checking for new versions of the project dependencies...
 starcounter-clientfiles#3.9.0 C:\Work\Starcounter\StarcounterClientFiles\src\StarcounterClientFiles
 ├─┬ enlighted-link#0.0.1
-│ └── webcomponentsjs#1.2.2 (latest is 2.0.2)
+│ └── webcomponentsjs#1.2.2 (1.2.3 available, latest is 2.0.3)
 ├─┬ imported-template#3.2.1
 │ └── juicy-html#4.0.0
 ├─┬ palindrom-client#7.1.0
@@ -9,12 +9,12 @@ starcounter-clientfiles#3.9.0 C:\Work\Starcounter\StarcounterClientFiles\src\Sta
 ├── palindrom-error-catcher#1.1.0
 ├── palindrom-redirect#1.0.0
 ├─┬ polymer-source#2.6.0 (latest is 3.0.2)
-│ ├── shadycss#1.3.1
-│ └── webcomponentsjs#1.2.2 (latest is 2.0.2)
-├─┬ starcounter-include#5.0.1
+│ ├── shadycss#1.3.1 (1.3.5 available)
+│ └── webcomponentsjs#1.2.2 (1.2.3 available, latest is 2.0.3)
+├─┬ starcounter-include#5.1.0
 │ └── imported-template#3.2.1
 ├─┬ uniform.css#0.4.1
-│ ├─┬ vaadin-date-picker#3.1.1 (3.2.0-alpha3 available)
+│ ├─┬ vaadin-date-picker#3.1.1 (3.2.0-alpha4 available)
 │ │ ├─┬ iron-a11y-announcer#2.1.0
 │ │ │ └── polymer not installed
 │ │ ├─┬ iron-a11y-keys-behavior#2.1.1
@@ -48,13 +48,13 @@ starcounter-clientfiles#3.9.0 C:\Work\Starcounter\StarcounterClientFiles\src\Sta
 │ │ │ │ └── polymer not installed
 │ │ │ └─┬ vaadin-themable-mixin#1.2.0
 │ │ │   └── polymer not installed
-│ │ ├─┬ vaadin-control-state-mixin#2.0.3 (2.1.0-alpha2 available)
+│ │ ├─┬ vaadin-control-state-mixin#2.0.3 (2.1.0 available)
 │ │ │ └── polymer not installed
 │ │ ├─┬ vaadin-element-mixin#1.1.1
 │ │ │ ├── polymer not installed
-│ │ │ ├─┬ vaadin-development-mode-detector#1.1.0-alpha2
+│ │ │ ├─┬ vaadin-development-mode-detector#1.1.0-alpha2 (latest is 2.0.0-alpha3)
 │ │ │ │ └── polymer not installed
-│ │ │ └─┬ vaadin-usage-statistics#1.1.0-alpha1
+│ │ │ └─┬ vaadin-usage-statistics#1.1.0-alpha1 (latest is 2.0.0-alpha3)
 │ │ │   └── polymer not installed
 │ │ ├─┬ vaadin-lumo-styles#1.0.0 (1.1.0-alpha3 available)
 │ │ │ ├─┬ iron-icon#2.1.0
@@ -68,7 +68,7 @@ starcounter-clientfiles#3.9.0 C:\Work\Starcounter\StarcounterClientFiles\src\Sta
 │ │ │ │ │ └── polymer not installed
 │ │ │ │ └── polymer not installed
 │ │ │ └── polymer not installed
-│ │ ├─┬ vaadin-overlay#3.0.3 (3.1.0-alpha2 available)
+│ │ ├─┬ vaadin-overlay#3.0.3 (3.1.0-alpha3 available)
 │ │ │ ├─┬ iron-overlay-behavior#2.3.4
 │ │ │ │ ├── iron-a11y-keys-behavior#2.1.1
 │ │ │ │ ├─┬ iron-fit-behavior#2.2.1
@@ -89,7 +89,7 @@ starcounter-clientfiles#3.9.0 C:\Work\Starcounter\StarcounterClientFiles\src\Sta
 │ │ │ │ │ └── polymer not installed
 │ │ │ │ └── polymer not installed
 │ │ │ └── vaadin-themable-mixin#1.2.0
-│ │ ├─┬ vaadin-text-field#2.0.1 (2.1.0-alpha2 available)
+│ │ ├─┬ vaadin-text-field#2.0.1 (2.1.0-alpha3 available)
 │ │ │ ├── polymer not installed
 │ │ │ ├─┬ vaadin-control-state-mixin#2.0.3
 │ │ │ │ └── polymer not installed
@@ -115,14 +115,14 @@ starcounter-clientfiles#3.9.0 C:\Work\Starcounter\StarcounterClientFiles\src\Sta
 │ │ │   └── polymer not installed
 │ │ └─┬ vaadin-themable-mixin#1.2.0
 │ │   └── polymer not installed
-│ ├─┬ vaadin-grid#5.0.4 (5.1.0-alpha2 available)
+│ ├─┬ vaadin-grid#5.0.4 (5.1.0-alpha3 available)
 │ │ ├── iron-a11y-announcer#2.1.0
 │ │ ├── iron-a11y-keys-behavior#2.1.1
 │ │ ├── iron-resizable-behavior#2.1.1
 │ │ ├─┬ iron-scroll-target-behavior#2.1.1
 │ │ │ └── polymer not installed
 │ │ ├── polymer not installed
-│ │ ├─┬ vaadin-checkbox#2.1.1 (2.2.0-alpha2 available)
+│ │ ├─┬ vaadin-checkbox#2.1.1 (2.2.0-alpha3 available)
 │ │ │ ├── polymer not installed
 │ │ │ ├─┬ vaadin-control-state-mixin#2.0.3
 │ │ │ │ └── polymer not installed
@@ -191,4 +191,4 @@ starcounter-clientfiles#3.9.0 C:\Work\Starcounter\StarcounterClientFiles\src\Sta
 │ │ └─┬ vaadin-themable-mixin#1.2.0
 │ │   └── polymer not installed
 │ └── webcomponentsjs#1.2.2
-└── webcomponentsjs#1.2.2 (latest is 2.0.2)
+└── webcomponentsjs#1.2.2 (1.2.3 available, latest is 2.0.3)

--- a/src/StarcounterClientFiles/bower.json
+++ b/src/StarcounterClientFiles/bower.json
@@ -6,7 +6,7 @@
     "palindrom-client": "^7.0.0",
     "imported-template": "^3.2.0",
     "palindrom-redirect": "~1.0.0",
-    "starcounter-include": "^5.0.0",
+    "starcounter-include": "^5.1.0",
     "polymer-source": "polymer#^2.0.0",
     "webcomponentsjs": "^1.0.0",
     "uniform.css": "^0.4.0",

--- a/src/StarcounterClientFiles/bower.json
+++ b/src/StarcounterClientFiles/bower.json
@@ -11,7 +11,8 @@
     "webcomponentsjs": "^1.0.0",
     "uniform.css": "^0.4.0",
     "enlighted-link": "^0.0.1",
-    "palindrom-error-catcher": "^1.0.0"
+    "palindrom-error-catcher": "^1.0.0",
+    "slot-all": "^0.0.1"
   },
   "resolutions": {
     "fast-json-patch": "^1.1.0",

--- a/src/StarcounterClientFiles/wwwroot/sys/slot-all/.bower.json
+++ b/src/StarcounterClientFiles/wwwroot/sys/slot-all/.bower.json
@@ -1,0 +1,38 @@
+{
+  "name": "slot-all",
+  "version": "0.0.1",
+  "description": "A custom element to distribute all elements regardless of their slot name",
+  "license": "MIT",
+  "main": "slot-all.html",
+  "keywords": [
+    "web-components",
+    "juicy"
+  ],
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "preview.png",
+    "package.json",
+    "Gruntfile.json"
+  ],
+  "dependencies": {
+    "webcomponentsjs": "^1.1.1"
+  },
+  "devDependencies": {
+    "web-component-tester": "^6.5.0",
+    "juicy-ace-editor": "^2.1.0"
+  },
+  "homepage": "https://github.com/Juicy/slot-all",
+  "_release": "0.0.1",
+  "_resolution": {
+    "type": "version",
+    "tag": "0.0.1",
+    "commit": "d238c280d438d1eda366a4e0f0652235892a531d"
+  },
+  "_source": "https://github.com/Juicy/slot-all.git",
+  "_target": "^0.0.1",
+  "_originalSource": "slot-all",
+  "_direct": true
+}

--- a/src/StarcounterClientFiles/wwwroot/sys/slot-all/CONTRIBUTING.md
+++ b/src/StarcounterClientFiles/wwwroot/sys/slot-all/CONTRIBUTING.md
@@ -1,0 +1,80 @@
+# Contributing
+
+We welcome and truly appreciate contribution in all forms - issues, pull requests, questions, or fancy examples of apps/elements build on to of your elements.
+
+## Filing bugs
+
+Our team heavily uses Github for all of our software management. We use Github issues to track all bugs and features.
+
+If you find an issue, please do file it on the repository.
+
+We love examples for addressing issues - issues with a Plunkr, [jsFiddle](http://jsfiddle.net), or [jsBin](http://jsbin.com) will be much easier for us to work on quickly. You can start with [this jsbin](http://jsbin.com/capequ/edit?html,output) which sets up the basics to demonstrate a Juicy element.
+
+Occasionally we'll close issues if they appear stale or are too vague - please don't take this personally! Please feel free to re-open issues we've closed if there's something we've missed and they still need to be addressed.
+
+## Developing the element
+
+If you would like to start to fiddle with element's code, here is the flow we use.
+
+- Make a local clone of this repo: `git clone git@github.com:Juicy/slot-all.git`
+
+In order to develop it locally we suggest to use [polyserve](https://npmjs.com/polyserve) tool to handle bower paths gently.
+
+0. Go to the repo's directory: `cd slot-all`
+1. Install [bower](http://bower.io/) & [polyserve](https://npmjs.com/polyserve): `$ npm install -g bower polyserve`
+2. Install local dependencies: `$ bower install`
+3. Start development server `$ polyserve -p 8000`
+4. Open the demo/preview: [http://localhost:8000/components/slot-all/](http://localhost:8000/components/slot-all/)
+5. Open the test suite: [http://localhost:8000/components/slot-all/test/](http://localhost:8000/components/slot-all/test/)
+
+## Contributing Pull Requests
+
+1. Fork it!
+2. Create your feature branch: `git checkout -b my-new-feature`
+3. Commit your changes: `git commit -m 'Add some feature'`
+4. Push to the branch: `git push origin my-new-feature`
+5. Open corresponding issue if needed
+6. Submit a pull request :D
+
+
+### Styleguide
+
+`.jscs.json`/`.jscsrc`/`package.json` to be linked
+
+## Unit tests
+
+All Juicy custom elements projects use [`web-component-tester`](https://github.com/Polymer/web-component-tester) for unit tests.
+The [`polyserve`](https://github.com/PolymerLabs/polyserve) utility is helpful for [running tests in the browser](#developing-the-element).
+
+
+
+### Running element unit tests from CLI
+
+To run the element unit tests from CLI, you need to:
+
+0.  Install `web-component-tester` globally: `npm install -g web-component-tester`
+1.  Clone the element repo.
+2.  Install the dependencies. `bower install`
+3.  Run the tests: `wct`
+
+#### Configuring `web-component-tester`
+
+By default, `web-component-tester` runs tests on all installed browsers. You can configure it
+to run tests on a subset of available browsers, or to run tests remotely using Sauce Labs.
+
+See the [`web-component-tester` README](https://github.com/Polymer/web-component-tester) for
+information on configuring the tool.
+
+## Releasing a new version
+
+**The release is done from `master` branch.**
+
+1. Make sure that the browser tests pass in Chrome, Firefox, Edge and IE. This can be done manually or using `npm run test` (see instructions above).
+2. Call `git status` to verify that there are no uncommited files in the directory
+3. Call `grunt bump:patch`, `grunt bump:minor` or `grunt bump:major`. This command:
+ - increments the version number in the relevant files
+ - commits changes to Git with the version number as the commit message
+ - creates a Git tag wit the version
+4. Call `git push` to push the changes to `origin master`
+5. Call `git push --tags` to push the tag to `origin master`
+6. Explain the changes (at least an summary of the commit log) in [GitHub Releases](https://github.com/Juicy/slot-all/releases).

--- a/src/StarcounterClientFiles/wwwroot/sys/slot-all/Gruntfile.js
+++ b/src/StarcounterClientFiles/wwwroot/sys/slot-all/Gruntfile.js
@@ -1,0 +1,24 @@
+module.exports = function(grunt) {
+
+    grunt.initConfig({
+        bump: {
+          options: {
+            files: ['package.json', 'bower.json', 'slot-all.html'],
+            commit: true,
+            commitMessage: '%VERSION%',
+            commitFiles: ['package.json', 'bower.json', 'slot-all.html'],
+            createTag: true,
+            tagName: '%VERSION%',
+            tagMessage: 'Version %VERSION%',
+            push: false,
+            // pushTo: 'origin',
+            globalReplace: false,
+            prereleaseName: false,
+            regExp: false
+          }
+        }
+    });
+;
+    grunt.loadNpmTasks('grunt-bump');
+
+};

--- a/src/StarcounterClientFiles/wwwroot/sys/slot-all/LICENSE
+++ b/src/StarcounterClientFiles/wwwroot/sys/slot-all/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) 2016 Starcounter AB
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/StarcounterClientFiles/wwwroot/sys/slot-all/README.md
+++ b/src/StarcounterClientFiles/wwwroot/sys/slot-all/README.md
@@ -1,0 +1,58 @@
+# &lt;slot-all&gt;
+
+A custom element to distribute all elements regardless of their slot name
+
+## Demo
+
+[Check it live!](http://Juicy.github.io/slot-all)
+
+## Install
+
+Install the component using [Bower](http://bower.io/):
+
+```sh
+$ bower install slot-all --save
+```
+
+Or [download as ZIP](https://github.com/Juicy/slot-all/archive/master.zip).
+
+## Usage
+
+1. Import polyfill:
+
+    ```html
+    <script src="bower_components/webcomponentsjs/webcomponent-lite.js"></script>
+    ```
+
+2. Import custom element:
+
+    ```html
+    <link rel="import" href="bower_components/slot-all/slot-all.html">
+    ```
+
+3. Start using it!
+
+    ```html
+    <div>
+        #shadow-root
+            <slot-all></slot-all>
+        <div slot="foo">Named slot</div>
+    </div>
+    ```
+
+## Caveats
+
+WebComponentsJS Shadow DOM polyfill has some limitations.
+It does ignore `node.remove()` and `.insertAdjacentElement()` calls,
+meaning it cannot be observed or reflected in shadow root. This result in `slot-all` element being unable to react on child nodes been added or removed using these methods. If you are targeting polyfilled environments try using `node.parentNode.removeChild(node)` and `insertBefore`.
+See issues https://github.com/webcomponents/shadydom/issues/260, https://github.com/webcomponents/shadydom/issues/261, https://github.com/webcomponents/shadydom/issues/262, https://github.com/webcomponents/shadydom/issues/263.
+
+## [Contributing and Development](CONTRIBUTING.md)
+
+## History
+
+For detailed changelog, check [Releases](https://github.com/Juicy/slot-all/releases).
+
+## License
+
+MIT

--- a/src/StarcounterClientFiles/wwwroot/sys/slot-all/bower.json
+++ b/src/StarcounterClientFiles/wwwroot/sys/slot-all/bower.json
@@ -1,0 +1,27 @@
+{
+  "name": "slot-all",
+  "version": "0.0.1",
+  "description": "A custom element to distribute all elements regardless of their slot name",
+  "license": "MIT",
+  "main": "slot-all.html",
+  "keywords": [
+    "web-components",
+    "juicy"
+  ],
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "preview.png",
+    "package.json",
+    "Gruntfile.json"
+  ],
+  "dependencies": {
+    "webcomponentsjs": "^1.1.1"
+  },
+  "devDependencies": {
+    "web-component-tester": "^6.5.0",
+    "juicy-ace-editor": "^2.1.0"
+  }
+}

--- a/src/StarcounterClientFiles/wwwroot/sys/slot-all/index.html
+++ b/src/StarcounterClientFiles/wwwroot/sys/slot-all/index.html
@@ -1,0 +1,114 @@
+<head>
+    <meta charset="utf-8">
+    <title>&lt;slot-all&gt;</title>
+    <link rel="stylesheet" href="http://juicy.github.io/github-markdown-css/github-markdown.css">
+
+    <!-- Imports polyfill -->
+    <script src="../webcomponentsjs/webcomponents-lite.js"></script>
+
+    <!-- Imports ace editor for nicer demo -->
+    <link rel="import" href="../juicy-ace-editor/juicy-ace-editor.html">
+
+    <!-- Imports custom element -->
+    <link rel="import" href="slot-all.html">
+    <style type="text/css">
+        html,
+        body {
+            height: 100%;
+        }
+
+        juicy-ace-editor{
+            margin: 15px;
+            width: calc(50% - 15px);
+            min-height: 10em;
+        }
+        div[shadow-host]{
+            width: calc(50% - 15px);
+        }
+
+        .markdown-body {
+            margin: 1em auto;
+            width: 70%;
+        }
+
+        .code-comparison {
+            display: flex;
+            justify-content: space-around;
+        }
+
+        iframe {
+            float: right;
+        }
+    </style>
+</head>
+
+<body class="markdown-body">
+    <iframe src="http://ghbtns.com/github-btn.html?user=juicy&amp;repo=slot-all&amp;type=fork&amp;count=true&amp;size=medium" allowtransparency="true" frameborder="0" scrolling="0" width="90" height="30"></iframe>
+    <iframe src="http://ghbtns.com/github-btn.html?user=juicy&amp;repo=slot-all&amp;type=watch&amp;count=true&amp;size=medium" allowtransparency="true" frameborder="0" scrolling="0" width="90" height="30"></iframe>
+    <h1>&lt;slot-all&gt;</h1>
+    <blockquote>
+        <p>
+            Custom element to distribute all elements regardless of their slot name
+        </p>
+    </blockquote>
+    <div class="code-comparison">
+        <juicy-ace-editor
+            theme="ace/theme/monokai"
+            mode="ace/mode/html">&lt;a slot="named"&gt;link&lt;/a&gt;
+&lt;div slot="named"&gt;div&lt;/div&gt;
+&lt;span slot="baz"&gt;span&lt;/span&gt;
+&lt;p&gt;default&lt;/p&gt;
+&lt;template is="shadow-root"&gt;
+    &lt;h3&gt;
+        Distribute all elements for named slots without knowing their names
+    &lt;/h3&gt;
+    &lt;slot-all&gt;&lt;/slot-all&gt;
+    &lt;slot&gt;&lt;/slot&gt;
+&lt;/template&gt;</juicy-ace-editor>
+
+        <div shadow-host>
+            <a slot="named">link</a>
+            <div slot="named">div</div>
+            <span slot="baz">span</span>
+            <p>default</p>
+            <template is="shadow-root">
+                <h3>
+                    Distribute all elements for named slots without knowing their names
+                </h3>
+                <slot-all></slot-all>
+                <slot></slot>
+            </template>
+        </div>
+    </div>
+
+
+    <h4>Looking for more specs? Check out the <a href="test/">test suite</a>.</h4>
+
+
+</body>
+<script>
+(function(){
+    // apply declarative shadow roots
+    function applyDSD(){
+        document.querySelectorAll('template[is="shadow-root"], template[is="declarative-shadow-dom"]').forEach((templ) => {
+            const host = templ.parentNode;
+            if(!host.shadowRoot){
+                host.attachShadow({
+                    mode: 'open'
+                });
+            } else {
+                host.shadowRoot.innerHTML = '';
+            }
+            host.shadowRoot.appendChild(document.importNode(templ.content, true));
+        });
+    }
+    // bound editor to the example
+    document.querySelector('juicy-ace-editor').addEventListener('change', (ev)=>{
+        document.querySelector('[shadow-host]').innerHTML = ev.target.value;
+        // trick Ace editor to adapt to the new content
+        window.dispatchEvent(new Event('resize'));
+        applyDSD();
+    });
+    applyDSD();
+}());
+</script>

--- a/src/StarcounterClientFiles/wwwroot/sys/slot-all/slot-all.html
+++ b/src/StarcounterClientFiles/wwwroot/sys/slot-all/slot-all.html
@@ -1,0 +1,140 @@
+<!-- slot-all @version: 0.0.1 @license: MIT -->
+<script>
+(function(){
+        /**
+         * A custom element to distribute all elements
+         * regardless of their slot name
+         *
+         * ```html
+         *     <div>
+         *         #shadow-root
+         *             <slot-all></slot-all>
+         *         <div slot="foo">Named slot</div>
+         *     </div>
+         * ```
+         */
+        customElements.define('slot-all', class SlotAll extends HTMLElement{
+            /**
+             * Initialize host observer and slots map.
+             */
+            constructor(){
+                super();
+                const slotAll = this;
+
+                // host observer instance
+                function mutationCallback(mutationsList){
+                    for(var mutation of mutationsList) {
+                        mutation.addedNodes.length && slotAll._createSlots(mutation.addedNodes);
+                        mutation.removedNodes.length && slotAll._removeSlots(mutation.removedNodes);
+                    }
+                }
+                // ShadyDOM breaks mutation observer, so we need to use its non-standard API
+                // workaround https://github.com/webcomponents/shadydom/issues/260
+                if(window.ShadyDOM && ShadyDOM.observeChildren){
+                    this.__shadyMutationCallback = mutationCallback;
+                } else {
+                    this._hostObserver = new MutationObserver(mutationCallback);
+                }
+                // map of created named slots
+                this.__createdSlots = new Map();
+            }
+            /**
+             * Observe adding and removing nodes to the shadow host,
+             * to create or remove named slots.
+             */
+            connectedCallback(){
+                const host = this.getRootNode().host;
+                // Start observing the shadow host for child list changes
+                // workaround https://github.com/webcomponents/shadydom/issues/260
+                if(window.ShadyDOM && this.__shadyMutationCallback){
+                    this.__shadyObserver = ShadyDOM.observeChildren(host, this.__shadyMutationCallback);
+                } else {
+                    this._hostObserver.observe(host, { childList: true });
+                }
+                // Create slots for initial list of children
+                this._createSlots(Array.from(host.children));
+            }
+            /**
+             * Disconnect host observer, remove created slots, clear the slots map.
+             */
+            disconnectedCallback(){
+                // unobserve host changes
+                this._hostObserver && this._hostObserver.disconnect();
+                // unobserve shady dom host changes
+                // workaround https://github.com/webcomponents/shadydom/issues/260
+                this.__shadyObserver && ShadyDOM.unobserveChildren(this.__shadyObserver);
+                for(let [name, slot] of this.__createdSlots){
+                    // workaround https://github.com/webcomponents/shadydom/issues/262
+                    // WC polyfill does not support .remove()
+                    // slot.remove();
+                    slot.parentNode && slot.parentNode.removeChild(slot);
+                }
+                this.__createdSlots.clear();
+            }
+            /**
+             * Create slots for given elements, if needed:
+             *  - element has a slot name,
+             *  - names slot was not yet created by this `slot-all``
+             * @param  {NodeList|HTMLCollection} nodeList list of host's children
+             */
+            _createSlots(nodeList){
+                const slotAll = this;
+                const slotsMap = slotAll.__createdSlots;
+
+                nodeList.forEach((element)=>{
+                    const name = element.slot;
+                    if(
+                        element.nodeType === Node.ELEMENT_NODE &&
+                        element.hasAttribute('slot') &&
+                        !slotsMap.has(name)
+                        // we do create a slot for elements already
+                        // assigned by other `slot(-all)`s
+                        // to handle distribution when others are removed.
+                        // !element.assignedSlot
+                    ){
+                        const namedSlot = document.createElement('slot');
+                        namedSlot.setAttribute('name', name);
+                        namedSlot.setAttribute('all-slotted', '');
+                        // add to the local map, to be able to clean it later
+                        slotsMap.set(name, namedSlot);
+                        // following is not supported by polyfill
+                        // slotAll.insertAdjacentElement('beforebegin', namedSlot);
+                        // workaround https://github.com/webcomponents/shadydom/issues/263
+                        slotAll.parentNode.insertBefore(namedSlot, slotAll);
+                    }
+                });
+            }
+            /**
+             * Remove slots for given elements, if needed:
+             *  - there are no more host's children with a slot name for the given slot name
+             * @param  {NodeList|HTMLCollection} nodeList list of removed host's children
+             */
+            _removeSlots(nodeList){
+                const slotAll = this;
+                let __createdSlots = this.__createdSlots;
+
+                nodeList.forEach((element)=>{
+                    if(element.nodeType === Node.ELEMENT_NODE){
+                        // element.assignedSlot no longer works,
+                        // we need to find the formerly assigned slot element manually
+                        const slotName = element.getAttribute('slot');
+                        // if host still has the elements with the same slot name,
+                        // we should keep the slot
+                        const slot = __createdSlots.get(slotName);
+                        // Polyfilled browsers do not have assignedElements
+                        // this time assignedNodes is somewhat safe to use
+                        // as we assume to support only names slots => elements
+                        // if(slot && slot.assignedElements().length == 0){
+                        if(slot && slot.assignedNodes().length == 0){
+                            // workaround https://github.com/webcomponents/shadydom/issues/262
+                            // WC polyfill does not support .remove()
+                            // slot.remove();
+                            slot.parentNode.removeChild(slot);
+                            __createdSlots.delete(slot);
+                        }
+                    }
+                });
+            }
+        });
+    })();
+</script>

--- a/src/StarcounterClientFiles/wwwroot/sys/slot-all/wct.conf.json
+++ b/src/StarcounterClientFiles/wwwroot/sys/slot-all/wct.conf.json
@@ -1,0 +1,18 @@
+{
+    "verbose": false,
+    "plugins": {
+        "local": {
+            "browsers": ["chrome", "firefox"]
+        },
+        "sauce": {
+            "browsers": [{
+                "browserName": "microsoftedge",
+                "platform": "Windows 10"
+            }, {
+                "browserName": "safari",
+                "platform": "OS X 10.11",
+                "version": "10"
+            }]
+        }
+    }
+}

--- a/src/StarcounterClientFiles/wwwroot/sys/starcounter-include/.bower.json
+++ b/src/StarcounterClientFiles/wwwroot/sys/starcounter-include/.bower.json
@@ -35,14 +35,15 @@
     "web-component-tester": "^6.0.0",
     "polymer": "^2.2.0"
   },
-  "version": "5.0.1",
-  "_release": "5.0.1",
+  "version": "5.1.0",
+  "_release": "5.1.0",
   "_resolution": {
     "type": "version",
-    "tag": "5.0.1",
-    "commit": "d8dad58eb9083c44e143a78d3d599cf148293070"
+    "tag": "5.1.0",
+    "commit": "b91cb9e98d8557b62b6bc8b42ff4400c0daec90b"
   },
   "_source": "https://github.com/Starcounter/starcounter-include.git",
-  "_target": "^5.0.0",
-  "_originalSource": "starcounter-include"
+  "_target": "5.1.0",
+  "_originalSource": "starcounter-include",
+  "_direct": true
 }

--- a/src/StarcounterClientFiles/wwwroot/sys/starcounter-include/.bower.json
+++ b/src/StarcounterClientFiles/wwwroot/sys/starcounter-include/.bower.json
@@ -43,7 +43,6 @@
     "commit": "b91cb9e98d8557b62b6bc8b42ff4400c0daec90b"
   },
   "_source": "https://github.com/Starcounter/starcounter-include.git",
-  "_target": "5.1.0",
-  "_originalSource": "starcounter-include",
-  "_direct": true
+  "_target": "^5.1.0",
+  "_originalSource": "starcounter-include"
 }

--- a/src/StarcounterClientFiles/wwwroot/sys/starcounter-include/README.md
+++ b/src/StarcounterClientFiles/wwwroot/sys/starcounter-include/README.md
@@ -18,6 +18,7 @@ For more details see articles:
 
 - Fallback composition - a single `<style>:host{display: block;}</style><slot></slot>` to display all things from light DOM in case no composition was provided
 - Default composition - composition (or multiple concatenated compositions) found in the partial HTML view (`<template is="declarative-shadow-dom">` part)
+- Parent composition - composition found in the parent HTML view (content of `<starcounter-include ...><template is="declarative-shadow-dom" presentation="parent">`). It's used to enforce by parent view a given composition for any kind of elements.
 - Custom composition - stored composition provided in JSON by BlendingProvider
 - Temporary composition - explicit composition set directly in the shadow root of `starcounter-include` (for example by Chrome DevTools or `<starcounter-layout-html-editor>` in BlendingEditor)
 

--- a/src/StarcounterClientFiles/wwwroot/sys/starcounter-include/package.json
+++ b/src/StarcounterClientFiles/wwwroot/sys/starcounter-include/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starcounter-include",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "description": "Custom Element to include HTML partials/templates from Starcounter",
   "main": "starcounter-include.html",
   "directories": {

--- a/src/StarcounterClientFiles/wwwroot/sys/starcounter-include/starcounter-include.html
+++ b/src/StarcounterClientFiles/wwwroot/sys/starcounter-include/starcounter-include.html
@@ -4,7 +4,7 @@ Custom Element (w/ Polymer's TemplateBinding)
 with predefined template content, which should be used to include partials.
 It's just <imported-template> wrapped within Shadow Root for `declarative-shadow-dom` bindable by layout editor.
 Uses Shadow DOM given from DB as `Starcounter.MergedPartial.{_compositionProvider_}.Composition$`.
-version: 5.0.1
+version: 5.1.0
 
 -->
 <!-- Import dependencies -->
@@ -13,7 +13,7 @@ version: 5.0.1
 <script>
     (function() {
         function warnAboutDeprecatedPartial() {
-            console.warn('`partial` attribute and property are deprecatrd from `starcounter-include` in fovour of (viewModel property or view-model attribute), they will soon be no longer be supported');
+            console.warn('`partial` attribute and property are deprecated from `starcounter-include` in favour of (viewModel property or view-model attribute), they will soon be no longer be supported');
         }
         const isWebkit = navigator.vendor && navigator.vendor.indexOf("Apple") > -1;
 
@@ -108,10 +108,11 @@ version: 5.0.1
                     const importedTemplate = document.createElement('imported-template');
                     importedTemplate.addEventListener('stamping', function fetchCompositions(event) {
                         var mergedComposition = null;
-                        const templates = event.detail.querySelectorAll('template[is="declarative-shadow-dom"]');
+                        const templates = event.detail.querySelectorAll('template[is="declarative-shadow-dom"][presentation=default],template[is="declarative-shadow-dom"]:not([presentation])');
                         if(templates.length){
                             mergedComposition = document.createDocumentFragment();
                             for(const individualComposition of templates) {
+                                individualComposition.setAttribute('presentation', 'default');
                                 mergedComposition.appendChild(individualComposition.content.cloneNode(true));
                             };
                         }
@@ -232,7 +233,8 @@ version: 5.0.1
          * Handles change of the composition.
          * Temporary composition can be given explicitely in the function argument
          * If temporary composition not given, fetches custom composition from provider.
-         * If custom composition not given, fetches default composition from the imported template.
+         * If custom composition not given, fetches parent composition from the child `template`.
+         * If parent composition not given, fetches default composition from the imported template.
          * If default composition not given, uses fallback composition.
          * Warning: the temporary composition might come from https://github.com/Starcounter/starcounter-layout-html-editor/blob/17b21f729facd9a8dcd4241fb5c48cb71de11af5/starcounter-layout-html-editor.html#L253
          * @see .stampComposition
@@ -284,6 +286,18 @@ version: 5.0.1
                     this.partialId = null;
                 }
 
+                // Find parent composition to clone (if have one)
+                const parentCompositionTemplate = Array.from(this.children)
+                    .find((element)=>{
+                        return element.matches
+                            && element.matches('template[is="declarative-shadow-dom"][presentation="parent"],template[is="declarative-shadow-dom"]:not([presentation])')
+                    });
+                const parentComposition = parentCompositionTemplate && parentCompositionTemplate.content;
+                if (parentComposition) {
+                    parentCompositionTemplate.setAttribute('presentation', 'parent');
+                    this.temporaryComposition = null;
+                    return this._renderCompositionChange(parentComposition, () => parentComposition.cloneNode(true));
+                }
                 if (this.defaultComposition) {
                     this.temporaryComposition = null;
                     return this._renderCompositionChange(this.defaultComposition, () => this.defaultComposition.cloneNode(true));


### PR DESCRIPTION
- Add support for parent(host) composition,
   Update Starcounter/starcounter-include@5.1.0 (from 5.0.1)
   Starcounter/starcounter-include#102
- Add Juicy/slot-all element,
   to let app devs and solution owners distribute slotables regardless of their slot name
   Starcounter/RebelsLounge#368