### PR TITLE
Remove version from bower.json

### DIFF
--- a/src/StarcounterClientFiles/bower.json
+++ b/src/StarcounterClientFiles/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "starcounter-clientfiles",
-  "version": "3.15.0",
   "private": true,
   "dependencies": {
     "palindrom-client": "^7.0.0",


### PR DESCRIPTION
It's redundant, misleading and annoying to maintain. 