### PR TITLE
Fix link highlighting case-sensetivity

### DIFF
--- a/src/StarcounterClientFiles/wwwroot/sys/starcounter.html
+++ b/src/StarcounterClientFiles/wwwroot/sys/starcounter.html
@@ -5,7 +5,7 @@
     (function () {
         function updateCurrentLinks(currentHref) {
             document.querySelectorAll("a[href]").forEach(el => {
-                if (el.href === currentHref) {
+                if (el.href.toLowerCase() === currentHref.toLowerCase()) {
                     el.setAttribute('aria-current', "page")
                 } else if (el.hasAttribute('aria-current')) {
                     el.removeAttribute('aria-current')


### PR DESCRIPTION
Starcounter URLs are case-insensetive. Currently, the link isn't highlighted if the url has different case. This PR fixes this.