### PR TITLE
Add .bowerrc to the NuGet package,

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,20 @@
+## Development flow tips
+To slightly help with the "repolepsy" and make working with multiple repos and elements together easier, you may consider using [`bower link`](https://bower.io/docs/api/#link).
+- an keep the clone of some client package repo in a separate folder, for example `/path/to/imported-template`,
+- develop it there in isolation, use `polyserve`, `livereaload`, `wct`, etc,
+- call `bower link` in `imported-template` folder, so Bower could link to your working folder from whenever you want. Now you can share the same version of the element across other dependent packages and apps.
+  - call `bower link imported-template` from `path/to/starcounter-include` when you work with other package that needs it,
+  - call it from `/path/to/StarcounterClientFiles/src/StarcounterClientFiles` when you are running SCF as an app,
+  - call it from `C:\Program Files\Starcounter\ClientFiles` when you want to test it directly on any Starcounter solution you're running
+It creates just symlinks, so you will see the changes in `git status` of all joined repos, so you can easily revert and checkout needed versions.
+
 ## Testing your PR in TeamCity
 
 For your feature branch to be honoured by TeamCity, its name needs to start with `3.x` (eg: `3.x/fix-something`).
 
 ## Usage of StarcounterClientFiles 3.x in Level1 build automation
 
-Whatever is pushed on branch `3.x`, will be bundled in the Starcounter installer by the Level1 build automation. See [the announcement](https://github.com/Starcounter/AdminTrack/issues/438) for more details. 
+Whatever is pushed on branch `3.x`, will be bundled in the Starcounter installer by the Level1 build automation. See [the announcement](https://github.com/Starcounter/AdminTrack/issues/438) for more details.
 
 The name of the StarcounterClientFiles branch used by the Level1 build is configured via the `GIT_CLIENTFILES_BRANCH` parameter in TeamCity.
 
@@ -24,12 +34,12 @@ The developer process of releasing of a new version of StarcounterClientFiles `3
 7. After PR approval, still in PR branch publish a package of this version to App Warehouse (built with Starcounter 2.4). Follow the steps to do this [here](https://github.com/Starcounter/CompanyTrack/blob/master/AppsTeam/Guidelines/releasing-to-warehouse.md). But make sure to have cake dotnet CLI tool installed before this step: `dotnet tool install -g Cake.Tool`
    * this will create a nuget package of StarcounterClientFiles called `Starcounter.ClientFiles` to folder `/StarcounterClientFiles/artifacts/Starcounter.ClientFiles.X.Y.Z.nupkg`
 8. Execute [push_nuget_package.bat](https://github.com/Starcounter/StarcounterClientFiles/blob/3.x/push_nuget_package.bat)
-    * Requires full path to nupkg file + MyGet api key: 
-    
+    * Requires full path to nupkg file + MyGet api key:
+
     ```
     push_nuget_package.bat C:\StarcounterClientFiles\artifacts\Starcounter.ClientFiles.X.Y.Z.nupkg XXXXXXXXXXXXXXXXXXXXXX
     ```
-    
+
     Note that the newly added functionality is executed through Cake scripts, which makes it possible to execute through Bifrost as well. **This means that this new workflow adds the `nuget.exe` dependency. Please add the directory where your `nuget.exe` file is located to `%PATH%` environment variable**.
 
 9. Merge the PR to StarcounterClientFiles branch `3.x`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ## Development flow tips
 To slightly help with the "repolepsy" and make working with multiple repos and elements together easier, you may consider using [`bower link`](https://bower.io/docs/api/#link).
-- an keep the clone of some client package repo in a separate folder, for example `/path/to/imported-template`,
+ - keep the clone of some client package repo in a separate folder, for example `/path/to/imported-template`,
 - develop it there in isolation, use `polyserve`, `livereaload`, `wct`, etc,
 - call `bower link` in `imported-template` folder, so Bower could link to your working folder from whenever you want. Now you can share the same version of the element across other dependent packages and apps.
   - call `bower link imported-template` from `path/to/starcounter-include` when you work with other package that needs it,

--- a/nuget/Starcounter.ClientFiles.nuspec
+++ b/nuget/Starcounter.ClientFiles.nuspec
@@ -14,6 +14,7 @@
   <files>
     <file src="..\src\StarcounterClientFiles\wwwroot\sys\**" target="contentFiles/any/any/ClientFiles/StaticFiles/sys" />
     <file src="..\src\StarcounterClientFiles\bower.json" target="contentFiles/any/any/ClientFiles" />
+    <file src="..\src\StarcounterClientFiles\.bowerrc" target="contentFiles/any/any/ClientFiles" />
     <file src="..\src\StarcounterClientFiles\bower-list.txt" target="contentFiles/any/any/ClientFiles" />
   </files>
 </package>


### PR DESCRIPTION
to make `bower link clientPackage` work out of the box for Starcounter installation folder