### PR TITLE
Problem 85: simple 404.html page was added.

### DIFF
--- a/src/StarcounterClientFiles/wwwroot/sys/error/404.html
+++ b/src/StarcounterClientFiles/wwwroot/sys/error/404.html
@@ -1,0 +1,1 @@
+<template><h1>404 Page Not Found</h1></template>


### PR DESCRIPTION
[**Problem 85**](https://github.com/Starcounter/Starcounter.Authorization/issues/85):
>We have a problem with how the Authorization library handles the unauthorized/unauthenticated cases.
If you are unauthorized to access a particular page it sends a 404 without a body, which crashes the session irrecoverably.

**Solution:**
As the part of the solution for fixing https://github.com/Starcounter/Starcounter.Authorization/issues/85 we decided to add simple static 404.html page. 