### PR TITLE
Use NuGet instead of MyGet

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -12,7 +12,7 @@
     /// Argument parsing
     ///
     string configuration = Argument("configuration", "Debug");
-    string mygetApiKey = Argument("mygetApiKey", "");
+    string nugetApiKey = Argument("nugetApiKey", "");
     string nuGetPackageFile = Argument("clientFilesNupkgFile", "");
     string starNugetPath = Argument("starNugetPath", "");
     if (string.IsNullOrEmpty(starNugetPath))
@@ -79,9 +79,9 @@
     ///
     Task("PushClientFiles").Does(() =>
     {
-        if (string.IsNullOrEmpty(mygetApiKey))
+        if (string.IsNullOrEmpty(nugetApiKey))
         {
-            throw new Exception("MyGet API key has not been set, aborting! Set argument --mygetApiKey");
+            throw new Exception("NuGet API key has not been set, aborting! Set argument --nugetApiKey");
         }
 
         FileInfo fi = new FileInfo(nuGetPackageFile);
@@ -92,8 +92,8 @@
 
         var nuGetPushSettings = new NuGetPushSettings
         {
-            Source = "https://www.myget.org/F/starcounter/api/v2/package",
-            ApiKey = mygetApiKey
+            Source = "https://api.nuget.org/v3/index.json",
+            ApiKey = nugetApiKey
         };
 
         NuGetPush(fi.FullName, nuGetPushSettings);

--- a/push_nuget_package.bat
+++ b/push_nuget_package.bat
@@ -14,7 +14,7 @@ if "%2" == "" (
     goto end
 )
 
-dotnet cake %~dp0build.cake --targets="PushClientFiles" --clientFilesNupkgFile="%1" --mygetApiKey="%2" --verbosity=Normal || exit /b %errorlevel%
+dotnet cake %~dp0build.cake --targets="PushClientFiles" --clientFilesNupkgFile="%1" --nugetApiKey="%2" --verbosity=Normal || exit /b %errorlevel%
 
 :end
 exit /b 0


### PR DESCRIPTION
Changed publishing script to publish on NuGet instead of MyGet. Tested and all works. 

Also with help from @per-samuelsson, SCF is now unlisted on MyGet so NuGet will take precedence when Starcounter.ClientFiles package is fetched by `level1`. 

I'll update our passwords file with the creds of the NuGet account I created.